### PR TITLE
Add numpy as a build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython", "numpy == 1.26"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
-from setuptools import setup, Extension
+import numpy
 from Cython.Build import cythonize
+from setuptools import setup
 
 setup(
     name='mdvcontainment',
     version='0.1',
     packages=['mdvcontainment'],
     ext_modules=cythonize(["mdvcontainment/find_label_contacts.pyx", 'mdvcontainment/find_bridges.pyx']),
+    include_dirs=[numpy.get_include()],
     install_requires=[
         "numpy",
         "networkx",


### PR DESCRIPTION
To prevent an incompatibility with the changes to numpy integers in numpy 2.0 (i.e., `cnp.int_t` does not exist anymore; we could just use `int` there, as far as I understand), we must pin the numpy version for the build requirements to 1.26. (For now.)

The install_requirements (such as MDAnalysis) lead to the numpy install requirement being interpreted as ~1.26, so on the runtime end things are fine. The problem may have been screened away by build tests on systems that have a system-wide numpy<2.0 installation.